### PR TITLE
Adjust for random-fu >= 0.3

### DIFF
--- a/Data/Random/Show/Unsafe.hs
+++ b/Data/Random/Show/Unsafe.hs
@@ -17,8 +17,8 @@ module Data.Random.Show.Unsafe
 where
 
 import Data.Random.RVar
-import Data.Random.Source.DevRandom
 import System.IO.Unsafe
+import System.Random.Stateful
 
 instance (Show a) => Show (RVar a) where
-    show rv = show . unsafePerformIO $ runRVar rv DevURandom
+    show rv = show . unsafePerformIO $ runRVar rv globalStdGen

--- a/random-extras.cabal
+++ b/random-extras.cabal
@@ -20,17 +20,15 @@ Library
         Data.Random.Distribution.Uniform.Exclusive,
         Data.Random.Dovetail,
         Data.Random.Extras,
-        Data.Random.Shuffle.Weighted
-
-  if !os(windows)
-        Exposed-modules: Data.Random.Show.Unsafe
+        Data.Random.Shuffle.Weighted,
+        Data.Random.Show.Unsafe
   
   Build-depends:
         base >=4 && <5,
         containers >=0.3,
         array >=0.3,
-        random-fu ==0.2.*,
-        random-source ==0.3.*
+        random-fu ==0.3.*,
+        random == 1.2.*
   
   -- Other-modules:       
   


### PR DESCRIPTION
0.3 replaced random-source with the normal random package, so we can now
use a more portable globalStdGen fro Data.Random.Show.Unsafe.

We lose the dependency on random-source and incur one on random. The
lower bound on random-fu is increased.

Closes #4.